### PR TITLE
Unescape all URI escaped characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# tibco-ems-operator:44/2021-09-10
+
+* support unescaping of all escaped URI chars
+
 # tibco-ems-operator:43/2021-08-17
 
 * implement clippy recommendations

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,4 @@ env_logger = "0.9"
 tibco_ems = "0.3"
 # tibco_ems = { path = "../tibco-ems-rs", version = "0.3.7"}
 env-var = "1"
+urlencoding = "2.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tibco-ems-operator"
-version = "43.0.0"
+version = "44.0.0"
 authors = ["Jens Walter <jens@apimeister.com>"]
 edition = "2018"
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ use tibco_ems::admin::{QueueInfo, TopicInfo};
 use tibco_ems::Session;
 use std::panic;
 use std::process;
+use urlencoding::decode;
 
 mod queue;
 mod topic;
@@ -25,7 +26,7 @@ async fn respond(req: Request<Body>) -> Result<Response<Body>> {
     x if x.starts_with("/queue/") => {
       let prefix_rm_uri = uri.strip_prefix("/queue/").unwrap();
       let mut json_string;
-      let queue_name: String = prefix_rm_uri.replace("%7C", "|");
+      let queue_name: String = decode(prefix_rm_uri).unwrap().into_owned();
       if queue_name.contains('|') {
         //multiple queues
         let queue_list: Vec<&str> = queue_name.split('|').collect();
@@ -118,7 +119,7 @@ async fn respond(req: Request<Body>) -> Result<Response<Body>> {
     x if x.starts_with("/topic/") => {
       let prefix_rm_uri = uri.strip_prefix("/topic/").unwrap();
       let mut json_string;
-      let topic_name: String = prefix_rm_uri.replace("%7C", "|");
+      let topic_name: String = decode(prefix_rm_uri).unwrap().into_owned();
       if topic_name.contains('|') {
         //multiple topics
         let topic_list: Vec<&str> = topic_name.split('|').collect();


### PR DESCRIPTION
This closes Issue #7 and all future issues in that regard.  
All URI escaped characters are now unescaped if needed 